### PR TITLE
Issue65

### DIFF
--- a/app/analysis/views.py
+++ b/app/analysis/views.py
@@ -3824,7 +3824,7 @@ def remediate_emails():
         with get_db_connection(db_name) as db:
             c = db.cursor()
             c.execute("""SELECT archive_id, field, value FROM archive_search 
-                         WHERE ( field = 'message_id' OR field = 'env_to' ) 
+                         WHERE ( field = 'message_id' OR field = 'env_to' OR field = 'body_to' ) 
                          AND archive_id IN ( {} )""".format(','.join(['%s' for _ in archive_ids[db_name]])), 
                          tuple(archive_ids[db_name]))
 
@@ -3838,6 +3838,10 @@ def remediate_emails():
 
                 if field == 'env_to':
                     targets[archive_id].recipient = value.decode(errors='ignore')
+
+                # use body_to field as recipient if there is no env_to field
+                if field == 'body_to' and targets[archive_id].recipient is None:
+                    targets[archive_id].recipient = value
 
     # targets acquired -- perform the remediation or restoration
     params = [ ] # of tuples of ( message-id, email_address )

--- a/lib/saq/email.py
+++ b/lib/saq/email.py
@@ -112,6 +112,10 @@ def search_archive(source, message_ids, excluded_emails=[]):
             if field == 'env_to':
                 _buffer[archive_id].recipient = value
 
+            # use body_to field as recipient if there is no env_to field
+            if field == 'body_to' and _buffer[archive_id].recipient is None:
+                _buffer[archive_id].recipient = value
+
             if field == 'subject':
                 _buffer[archive_id].subject = value
 

--- a/lib/saq/remediation.py
+++ b/lib/saq/remediation.py
@@ -29,7 +29,7 @@ KEY_MESSAGE_ID = 'message_id'
 def _remediate_email_o365_EWS(emails):
     """Remediates the given emails specified by a list of tuples of (message-id, recipient email address)."""
     assert emails
-    assert all([len(e) == 2 and isinstance(e[0], str) and isinstance(e[1], str) for e in emails])
+    assert all([len(e) == 2 for e in emails])
 
     result = [] # tuple(message_id, recipient, result_code, result_text)
     
@@ -49,18 +49,16 @@ def _remediate_email_o365_EWS(emails):
     headers = { 'Content-Type': 'application/json' }
     
     for message_id, recipient in emails:
-
-        if recipient.startswith('<'):
-            recipient = recipient[1:]
-        if recipient.endswith('>'):
-            recipient = recipient[:-1]
-
-        data['recipient'] = recipient
-        data['message_id'] = message_id
-
-        json_data = json.dumps(data)
-
         try:
+            if recipient.startswith('<'):
+                recipient = recipient[1:]
+            if recipient.endswith('>'):
+                recipient = recipient[:-1]
+
+            data['recipient'] = recipient
+            data['message_id'] = message_id
+            json_data = json.dumps(data)
+
             logging.info("remediating message_id {} to {}".format(message_id, recipient))
             r = session.post(url, headers=headers, data=json_data, verify=False)
             logging.info("got result {} text {} for message_id {} to {}".format(r.status_code, r.text, message_id, recipient))
@@ -76,7 +74,7 @@ def _remediate_email_o365_EWS(emails):
 def _unremediate_email_o365_EWS(emails):
     """Remediates the given emails specified by a list of tuples of (message-id, recipient email address)."""
     assert emails
-    assert all([len(e) == 2 and isinstance(e[0], str) and isinstance(e[1], str) for e in emails])
+    assert all([len(e) == 2 for e in emails])
 
     result = [] # tuple(message_id, recipient, result_code, result_text)
     
@@ -96,17 +94,17 @@ def _unremediate_email_o365_EWS(emails):
     headers = { 'Content-Type': 'application/json' }
     
     for message_id, recipient in emails:
-        data['recipient'] = recipient
-        data['message_id'] = message_id
-
-        if recipient.startswith('<'):
-            recipient = recipient[1:]
-        if recipient.endswith('>'):
-            recipient = recipient[:-1]
-
-        json_data = json.dumps(data)
 
         try:
+            if recipient.startswith('<'):
+                recipient = recipient[1:]
+            if recipient.endswith('>'):
+                recipient = recipient[:-1]
+
+            data['recipient'] = recipient
+            data['message_id'] = message_id
+            json_data = json.dumps(data)
+
             logging.info("restoring message_id {} to {}".format(message_id, recipient))
             r = session.post(url, headers=headers, data=json_data, verify=False)
             logging.info("got result {} text {} for message_id {} to {}".format(r.status_code, r.text, message_id, recipient))


### PR DESCRIPTION
remediation history and modal now properly display the recipient address instead of none when the env_rcpt_to field is missing but a body_to field exists in the archive_search table.

Additionally remediation/restoration no longer asserts that all emails must be valid allowing remediation/restoration to fail on an individual rather than group basis.