### PR TITLE
#fixes #132 - added systemd stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ etc/api_logging.ini
 etc/blacklist.yar
 etc/remote_assignments.yar
 etc/saq.ini.saved
+etc/startupd
 
 # java decompiler
 bin/procyon-decompiler*

--- a/aced
+++ b/aced
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import os
+import os.path
+import psutil
+import signal
+import subprocess
+import time
+import traceback
+
+# stop service by raising a keyboard interrupt
+def stop_service(signum, frame):
+    raise KeyboardInterrupt()
+
+# setup shutdown handler
+signal.signal(signal.SIGTERM, stop_service)
+
+# list containing all subprocesses store in reverse start order
+subprocesses = []
+
+try:
+    # get installation directory
+    saq_home = '/opt/ace'
+    if 'SAQ_HOME' in os.environ:
+        saq_home = os.environ['SAQ_HOME']
+
+    # read list of commands to start from SAQ_HOME/etc/startupd
+    startup_path = os.path.join(saq_home, "etc", "startupd")
+    with open(startup_path, 'r') as f:
+        commands = f.readlines()
+
+    # get path to ace executable
+    ace_path = os.path.join(saq_home, "ace")
+
+    # start all listed commands
+    for command in commands:
+        # skip empty lines and comments
+        command = command.strip()
+        if command is None or command == "" or command.startswith("#"):
+            continue
+
+        engine, log_config = command.split()
+        log_config_path = os.path.join("etc", log_config)
+
+        # start the engine
+        print("Starting {}".format(engine))
+        p = subprocess.Popen(["python3", ace_path, "--start", "-L", log_config_path, engine])
+        subprocesses.insert(0, psutil.Process(p.pid))
+
+    # wait until told to stop by keyboard interrupt/sigterm
+    while True:
+        time.sleep(0.1)
+
+# use keyboard interrupt as signal for shutdown
+except KeyboardInterrupt:
+    pass
+
+# stop all subprocesses
+for p in subprocesses:
+    try:
+        # ask process to stop gracefully
+        p.terminate()
+
+        # give the process some time to shutdown gracefully
+        try:
+            p.wait(timeout=60)
+
+        # if the process did not shutdown gracefully in a reasonable amount of time then kill process tree
+        except Exception:
+            # kill all children
+            for child in p.children(recursive=True):
+                child.kill()
+
+            # kill main process
+            p.kill()
+
+    except Exception as e:
+        print("unable to stop process {}: {}".format(p, e))

--- a/etc/startupd.default
+++ b/etc/startupd.default
@@ -1,0 +1,14 @@
+# the services will be started in the following order
+# (and then stopped in reverse order)
+# comment out the services you don't want to use
+# engine		logging config
+
+carbon-black		carbon_black_logging.ini
+cb-binary-collector	cb_collector_logging.ini
+correlation-engine	ace_logging.ini
+email-collector		email_collection_logging.ini
+bro-http-collector	http_collector_logging.ini
+network-semaphore	network_semaphore_logging.ini
+bro-smtp-collector	smtp_collector_logging.ini
+#start-gui		gui_logging.ini
+#start-api		api_logging.ini

--- a/etc/startupd.dev
+++ b/etc/startupd.dev
@@ -1,0 +1,14 @@
+# the services will be started in the following order
+# (and then stopped in reverse order)
+# comment out the services you don't want to use
+# engine		logging config
+
+carbon-black		carbon_black_logging.ini
+cb-binary-collector	cb_collector_logging.ini
+correlation-engine	ace_logging.ini
+email-collector		email_collection_logging.ini
+bro-http-collector	http_collector_logging.ini
+network-semaphore	network_semaphore_logging.ini
+bro-smtp-collector	smtp_collector_logging.ini
+start-gui		gui_logging.ini
+start-api		api_logging.ini

--- a/installer/install_service.sh
+++ b/installer/install_service.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# install the service if systemd exists
+if [ -d "/etc/systemd/system/" ]
+then
+	# allow setting user from first arg
+	SERVICE_USER="ace"
+	if [ "$#" -ge 1 ]
+	then
+		SERVICE_USER="$1"
+	fi
+
+	# allow setting group from second arg
+	SERVICE_GROUP="ace"
+	if [ "$#" -ge 2 ]
+	then
+		SERVICE_GROUP="$2"
+	fi
+
+	# create symlink to startupd config
+	ln -s startupd.default $SAQ_HOME/etc/startupd
+
+	# create the service config file
+	echo "[Unit]" | sudo tee /etc/systemd/system/ace.service
+	echo "Description=ace" | sudo tee -a /etc/systemd/system/ace.service
+	echo "" | sudo tee -a /etc/systemd/system/ace.service
+	echo "[Service]" | sudo tee -a /etc/systemd/system/ace.service
+	echo "Type=simple" | sudo tee -a /etc/systemd/system/ace.service
+	echo "User=$SERVICE_USER" | sudo tee -a /etc/systemd/system/ace.service
+	echo "Group=$SERVICE_GROUP" | sudo tee -a /etc/systemd/system/ace.service
+	echo "Restart=always" | sudo tee -a /etc/systemd/system/ace.service
+	echo "WorkingDirectory=$SAQ_HOME" | sudo tee -a /etc/systemd/system/ace.service
+	echo "ExecStart=$SAQ_HOME/aced" | sudo tee -a /etc/systemd/system/ace.service
+	echo "" | sudo tee -a /etc/systemd/system/ace.service
+	echo "[Install]" | sudo tee -a /etc/systemd/system/ace.service
+	echo "WantedBy=multi-user.target" | sudo tee -a /etc/systemd/system/ace.service
+fi


### PR DESCRIPTION
added an install_service script that creates a systemd service config for ace.

after running the install script you can start and stop all configured engines of ace by running:

```
sudo systemctl start ace
sudo systemctl stop ace
```

Enable and disable starting ace on boot with:

```
sudo systemctl enable ace
sudo systemctl disable ace
```

You can change what engines are started by the ace service by editing the etc/startupd file. You can also optionally start the api and gui.
Note: the startupd file is a symlink so you can create custom startupd configs and ignore them in git

You can also run the ace service directly in the console:

```
./aced
```

pressing ctrl+c will stop the service in the console