### PR TITLE
152

### DIFF
--- a/lib/saq/__init__.py
+++ b/lib/saq/__init__.py
@@ -148,7 +148,7 @@ def set_node(name):
         SAQ_NODE_ID = None
         initialize_node()
 
-def initialize(saq_home=None, config_paths=None, logging_config_path=None, args=None, relative_dir=None):
+def initialize(saq_home=None, config_paths=None, logging_config_path=None, args=None, relative_dir=None, unittest=False):
 
     from saq.database import initialize_database, initialize_node
 
@@ -307,6 +307,11 @@ def initialize(saq_home=None, config_paths=None, logging_config_path=None, args=
 
     # if $SAQ_HOME/etc/saq.ini exists then we use that as the last config if it's not already specified
     default_config_path = os.path.join(SAQ_HOME, 'etc', 'saq.ini')
+
+    # use unit test config if we are running a unit test
+    if unittest:
+        default_config_path = os.path.join(SAQ_HOME, 'etc', 'saq.unittest.ini')
+
     if os.path.exists(default_config_path):
         if default_config_path not in CONFIG_PATHS:
             CONFIG_PATHS.append(default_config_path)

--- a/lib/saq/test.py
+++ b/lib/saq/test.py
@@ -297,7 +297,7 @@ def initialize_test_environment():
     import saq
     saq.initialize(saq_home=saq_home, config_paths=[], 
                    logging_config_path=os.path.join(saq_home, 'etc', 'unittest_logging.ini'), 
-                   args=None, relative_dir=None)
+                   args=None, relative_dir=None, unittest=True)
 
     if saq.CONFIG['global']['instance_type'] not in [ 'PRODUCTION', 'QA', 'DEV' ]:
         sys.stderr.write('\n\n *** CRITICAL ERROR *** \n\ninvalid instance_type setting in configuration\n')

--- a/test
+++ b/test
@@ -10,25 +10,6 @@ cd "${SAQ_HOME}" || { echo "cannot cd to ${SAQ_HOME}"; exit 1; }
 
 rm -rf error_reports/* 2> /dev/null
 
-# make sure we're using the saq.unittest.ini config
-if [ ! -L etc/saq.ini ]
-then
-    echo "etc/saq.ini should be a symlink"
-    exit 1
-fi
-
-if [ "$(readlink etc/saq.ini)" != "saq.unittest.ini" ]
-then
-    echo "switching to saq.unittest.ini"
-    cp etc/saq.ini etc/saq.ini.saved
-    rm etc/saq.ini && ln -s saq.unittest.ini etc/saq.ini
-    if [ "$(readlink etc/saq.ini)" != "saq.unittest.ini" ]
-    then
-        echo "unable to set config"
-        exit 1
-    fi
-fi
-
 # clear logs
 if [ -e logs/unittest.log ]
 then


### PR DESCRIPTION
unit testing now uses saq.unittest.ini as default config rather than altering the saq.ini symlink