### PR TITLE
correted docstring error+warning and bug in ace script

### DIFF
--- a/ace
+++ b/ace
@@ -2639,7 +2639,7 @@ WHERE
                         logging.error(f"unable to delete {target_file}: {e}")
 
         for sha256_url, sha256_content in results:
-            c.execute("DELETE FROM cloudphish_analysis_results WHERE sha256_url = UNHEX('%s')", (sha256_url,))
+            c.execute("DELETE FROM cloudphish_analysis_results WHERE sha256_url = UNHEX(%s)", (sha256_url,))
             url_counter += 1
             if url_counter % 100 == 0:
                 db.commit()

--- a/ace_api.py
+++ b/ace_api.py
@@ -552,16 +552,16 @@ class Analysis(object):
 
     :param str discription: (optional) A brief description of this analysis data (Why? What? How?).
     :param str analysis_mode: (optional) The ACE mode this analysis should be put into. 'correlation' will force an
-    alert creation. 'analysis' will only alert if a detection is made. Default: 'analysis'
+        alert creation. 'analysis' will only alert if a detection is made. Default: 'analysis'
     :param str tool: (optional) The "tool" that is submitting this analysis. Meant for distinguishing your custom
-    hunters and detection tools. Default: 'ace_api'.
+        hunters and detection tools. Default: 'ace_api'.
     :param str tool_instance: (optional) The instance of the tool that is submitting this analysis.
     :param str type: (optional) The type of analysis this is, kinda like the focus of the alert. Mainly used internally
-    by some ACE modules. Default: 'generic'
+        by some ACE modules. Default: 'generic'
     :param datetime event_time: (optional) Assign a time to this analysis. Usually, the time associated to what ever
-    event triggered this analysis creation. Default: now()
+        event triggered this analysis creation. Default: now()
     :param dict details: (optional) A dictionary of additional details to get added to the alert, think notes and
-    comments.
+        comments.
     :param list observables: (optional) A list of observables to add to the request.
     :param list tags: (optional) If this request becomes an Alert, these tags will get added to it.
     :param list files: (optional) A list of (file_name, file_descriptor) tuples to be included in this ACE request.
@@ -743,8 +743,8 @@ class Analysis(object):
 
         :param str filename: The name of the file. Assumed to be a valid path to the file if data_or_fp is None.
         :param data_or_fp: (optional) A string or file pointer.
-        :param str relative_storage_path: (optional) Where the file should be stored, relative to the analysis 
-        directory. Default is the root of the analysis.
+        :param str relative_storage_path: (optional) Where the file should be stored, relative to the analysis
+            directory. Default is the root of the analysis.
         :type data_or_fp: str or bytes or None or _io.TextIOWrapper or _io.BufferedReader 
         """
         # get just the file name

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,8 +222,6 @@ A python library exits for intereacting with the ACE API. You can install it wil
 
 .. autofunction:: ace_api.get_analysis
 
-.. autofunction:: ace_api.load_analysis
-
 .. autofunction:: ace_api.download
 
 .. autofunction:: ace_api.upload


### PR DESCRIPTION
- WARNING: autodoc: failed to import function 'load_analysis' from module 'ace_api'

- Field list ends without a blank line; unexpected unindent

- error in your SQL syntax on ace.cleanup_cloudphish